### PR TITLE
Fix error in Volume observation

### DIFF
--- a/pulse_adjoint/model_observations.py
+++ b/pulse_adjoint/model_observations.py
@@ -132,7 +132,7 @@ class VolumeObservation(ModelObservation):
         dmu,
         approx="project",
         displacement_space="CG_2",
-        interpolation_space="CG_1",
+        interpolation_space="CG_2",
         description="",
     ):
         ModelObservation.__init__(
@@ -264,7 +264,7 @@ class StrainObservation(ModelObservation):
         F_ref=None,
         isochoric=True,
         displacement_space="CG_2",
-        interpolation_space="CG_1",
+        interpolation_space="CG_2",
         description="",
     ):
 

--- a/tests/test_model_observations.py
+++ b/tests/test_model_observations.py
@@ -1,5 +1,6 @@
 import dolfin
 import dolfin_adjoint
+import fixtures
 import numpy as np
 import pulse
 import pytest
@@ -15,6 +16,25 @@ V_cg2 = dolfin.VectorFunctionSpace(geo.mesh, "CG", 2)
 
 def norm(v):
     return np.linalg.norm(v)
+
+
+def test_volume_observation_is_same_as_geometry_cavity_volume_zero():
+
+    problem, control = fixtures.create_problem("R_0")
+    u, p = dolfin.split(problem.state)
+
+    volume_obs = VolumeObservation(mesh=geo.mesh, dmu=geo.ds(geo.markers["ENDO"]))
+    assert abs(problem.geometry.cavity_volume(u=u) - float(volume_obs(u))) < 1e-12
+
+
+def test_volume_observation_is_same_as_geometry_cavity_volume_nonzero():
+
+    problem, control = fixtures.create_problem("R_0")
+    pulse.iterate.iterate(problem, problem.bcs.neumann[0].traction, 0.1)
+    u, p = dolfin.split(problem.state)
+
+    volume_obs = VolumeObservation(mesh=geo.mesh, dmu=geo.ds(geo.markers["ENDO"]))
+    assert abs(problem.geometry.cavity_volume(u=u) - float(volume_obs(u))) < 1e-12
 
 
 @pytest.mark.parametrize("approx", ("project", "interpolate", "original"))
@@ -135,4 +155,5 @@ def test_boundary_observation():
 
 
 if __name__ == "__main__":
-    test_boundary_observation()
+    # test_boundary_observation()
+    test_volume_observation_is_same_as_geometry_cavity_volume_nonzero()

--- a/tests/test_reduced_functional.py
+++ b/tests/test_reduced_functional.py
@@ -1,0 +1,44 @@
+import dolfin
+import fixtures
+import pulse
+
+import pulse_adjoint
+
+
+def test_create_reduced_functional():
+
+    start_control = 1.0
+    target_control = 2.0
+    target_pressure = 0.5
+
+    problem, control = fixtures.create_problem("R_0", control_value=start_control)
+    problem2, control2 = fixtures.create_problem("R_0", control_value=target_control)
+
+    pressure_data = [target_pressure]
+
+    pulse.iterate.iterate(problem2, problem2.bcs.neumann[0].traction, target_pressure)
+    u, p = dolfin.split(problem2.state)
+
+    volume_data = [problem2.geometry.cavity_volume(u=u)]
+
+    # Create volume observersion
+    endo = problem.geometry.markers["ENDO"][0]
+    volume_model = pulse_adjoint.model_observations.VolumeObservation(
+        problem.geometry.mesh, problem.geometry.ds(endo)
+    )
+    volume_target = pulse_adjoint.OptimizationTarget(volume_data, volume_model)
+
+    pressure_obs = pulse_adjoint.model_observations.BoundaryObservation(
+        problem.bcs.neumann[0], pressure_data
+    )
+
+    assimilator = pulse_adjoint.Assimilator(
+        problem, targets=[volume_target], bcs=pressure_obs, control=control
+    )
+
+    rd = assimilator.create_reduced_functional()
+    assert abs(rd(target_control)) < 1e-12
+
+
+if __name__ == "__main__":
+    test_create_reduced_functional()


### PR DESCRIPTION
In the `VolumeObservation`, one of the arguments is the given displacement space and a space for interpolating the displacement. 

https://github.com/ComputationalPhysiology/pulse_adjoint/blob/master/pulse_adjoint/model_observations.py#L134-L135

This was mainly used during the unloaded optimization in the original code because when unloading we perform an [`ALE.move`](https://fenics-dolfin.readthedocs.io/en/2017.2.0/apis/api_ale.html). In that case we move all vertices in a mesh with a given displacement, and since the mesh is linear the displacement that we move with is first interpolated onto a CG 1 space. In other words for a given displacement we want the volume of the ventricle to be the same whether the displacement is used directly in the [volume form](https://github.com/ComputationalPhysiology/pulse_adjoint/blob/b956769c0e701733346e42fdcef59bd0b9d285d4/pulse_adjoint/model_observations.py#L190) or if we first move the mesh and then compute the volume without the displacement in the volume form. However, this seems to not work anymore, which is something we need to have in mind when implementing the optimisations with unloading. 